### PR TITLE
Update to search logic to use find

### DIFF
--- a/heic-converter/heic-converter.sh
+++ b/heic-converter/heic-converter.sh
@@ -18,7 +18,7 @@ else
     done
 
     #look for files in current path that contains ".heic" OR ".HEIC"
-    for file in $( ls | grep -E ".heic|.HEIC")
+    for file in $( find . -name "*.heic" -o -name "*.HEIC" -type f )
     do
         echo "Converting file: $file"
         sedCommand="s/heic/${fileExtension}/g;s/HEIC/${fileExtension}/g"


### PR DESCRIPTION
Using find for file types is adding recursive  search for large libraries which allows the script to be re-run in root of the library and convert any .heic or .HEIC file.
This will work flawlessly if the process flow for image file management is:
 - convert all heic files to desired PNG or JPG
 - re file duplicate finder and delete all HEIC or move them out of the library
 - for future files imports re-run the heic-converter.sh again
 - rinse and repeat